### PR TITLE
Add MITM Proxy support w/ TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ENV/
 credentials/**/* */
 
 ./backups/**/*
+service-mappings.md

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,6 @@ lint:
 install-docker:
 	ansible-playbook playbooks/tools/install-docker.yml
 
-deploy-postgres:
-	ansible-playbook playbooks/containers/postgres.yml
-
-deploy-gitea:
-	ansible-playbook playbooks/containers/gitea.yml
-
 create-container:
 	@scripts/create-container.sh
 
@@ -28,11 +22,11 @@ remove-container:
 	@scripts/remove-container.sh
 
 # Dynamic targets
-deploy-%:
+prod-deploy-%:
 	@if [ -f "playbooks/containers/$*.yml" ]; then \
 		ansible-playbook -i inventory/production playbooks/containers/$*.yml \
-			--vault-password-file=credentials/.vault_pass \
-			--become-password-file=credentials/.become_pass; \
+			--become-password-file=credentials/.become_pass \
+			--vault-password-file=credentials/.vault_pass; \
 	else \
 		echo "No playbook found for $*"; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -5,15 +5,6 @@
 
 Automated deployment and management of Docker containers in a homelab environment using Ansible. This repository contains scripts, playbooks, and templates for maintaining a consistent and reproducible infrastructure.
 
-## ✨ Features
-
-- 🐳 Docker container deployment automation
-- 📝 Templated service configurations
-- 🔄 Lifecycle management with pre/post hooks
-- 🔐 Secure secrets management with Ansible Vault
-- 📁 Standardized directory structure
-- 🧰 Utility scripts for common operations
-
 ## 🚀 Quick Start
 
 ```bash

--- a/inventory/dev/hosts
+++ b/inventory/dev/hosts
@@ -11,3 +11,6 @@ gitea1 ansible_host="192.168.66.9" node_type=worker ansible_ssh_common_args='-o 
 
 [syncthing]
 syncthing1 ansible_host="192.168.66.8" node_type=worker ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[mitmproxy]
+mitmproxy1 ansible_host="192.168.66.8" node_type=worker ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/inventory/production/hosts
+++ b/inventory/production/hosts
@@ -8,6 +8,8 @@ db1 ansible_host=155.155.155.2
 
 [gitea]
 gitea1 ansible_host=155.155.155.2
+gitea2 ansible_host=155.155.155.3
+gitea3 ansible_host=155.155.155.4
 
 [syncthing]
 syncthing1 ansible_host=155.155.155.2

--- a/inventory/production/hosts
+++ b/inventory/production/hosts
@@ -11,3 +11,6 @@ gitea1 ansible_host=155.155.155.2
 
 [syncthing]
 syncthing1 ansible_host=155.155.155.2
+
+[mitmproxy]
+mitmproxy1 ansible_host=155.155.155.4

--- a/playbooks/containers/mitmproxy.yml
+++ b/playbooks/containers/mitmproxy.yml
@@ -1,0 +1,15 @@
+---
+- name: Deploy Mitmproxy
+  hosts: mitmproxy
+  become: true
+  vars_files:
+    - ../../group_vars/all/all.yml
+    - ../../vars/mitmproxy/main.yml
+  roles:
+    - role: docker
+      vars:
+        # rollback: true
+        # debug: true
+        container_volumes:
+          - mitmproxy
+        container_name: "mitmproxy"

--- a/roles/mitmproxy/tasks/post_deploy.yml
+++ b/roles/mitmproxy/tasks/post_deploy.yml
@@ -1,0 +1,4 @@
+---
+- name: Demo Post Deploy Task
+  debug:
+    msg: "This is post_deploy task"

--- a/roles/mitmproxy/tasks/post_healthy.yml
+++ b/roles/mitmproxy/tasks/post_healthy.yml
@@ -1,0 +1,4 @@
+---
+- name: Demo Post Healthy Task
+  debug:
+    msg: "This is post_healthy task"

--- a/roles/mitmproxy/tasks/pre_deploy.yml
+++ b/roles/mitmproxy/tasks/pre_deploy.yml
@@ -1,0 +1,4 @@
+---
+- name: Demo Pre Deploy Task
+  debug:
+    msg: "This is pre_deploy task"

--- a/templates/mitmproxy/docker-compose.yml
+++ b/templates/mitmproxy/docker-compose.yml
@@ -1,44 +1,75 @@
-# services:
-#   mitmproxy:
-#     image: mitmproxy/mitmproxy
-#     container_name: "{{ service_config.name }}"
-#     restart: always
-#     networks:
-#       mitmproxy_net:
-#         ipv4_address: "{{ service_config.ip_address }}"
-#     command:
-#       - mitmweb
-#       - --mode
-#       - regular@{{ service_config.port }}
-#     ports:
-#       - "{{ service_config.port }}:8082"
-#     healthcheck:
-#       test: "curl -fSs http://localhost:{{ service_config.port }} || exit 1"
-#       interval: 5s
-#       timeout: 10s
-#       retries: 5
-#       start_period: 30s
-
-# networks:
-#   mitmproxy_net:
-#     name: mitmproxy_net
-#     driver: bridge
-#     ipam:
-#       driver: default
-#       config:
-#         - subnet: "172.25.0.0/24"
 services:
   mitmweb:
     image: mitmproxy/mitmproxy
     container_name: "mitmproxy"
     tty: true
     ports:
-      - "8080:8080" # Web interface
-      - "8081:8081" # Proxy port
-    command: mitmweb --web-host 0.0.0.0
+      # Proxy port
+      - "8585:8080"
+      # Web interface
+      - "9595:9090"
+    volumes:
+      - mitmproxy_certs:/home/mitmproxy/.mitmproxy
+    command:
+      - mitmweb
+      - "--web-host"
+      - "0.0.0.0"
+      - "--web-port"
+      - "9090"
+      - "--listen-port"
+      - "8080"
+      - "--listen-host"
+      - "0.0.0.0"
+      # Enable TLS interception
+      - "--mode"
+      - "regular"
+      # Set certificate generation
+      - "--set"
+      - "confdir=/home/mitmproxy/.mitmproxy"
+      # Skip intercepting own traffic
+      - "--ignore-hosts"
+      - "^172.25.0.1(0|1)$"
+    networks:
+      mitmproxy_net:
+        ipv4_address: "172.25.0.10"
     healthcheck:
-      test: "curl -f http://localhost:8081 || exit 1"
+      test: ["CMD", "true"]
       interval: 5s
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx.Dockerfile
+    container_name: "mitmproxy-cert"
+    ports:
+      - "8484:443"
+    volumes:
+      - mitmproxy_certs:/usr/share/nginx/certs:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    networks:
+      mitmproxy_net:
+        ipv4_address: "172.25.0.11"
+    depends_on:
+      - mitmweb
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+networks:
+  mitmproxy_net:
+    name: mitmproxy_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.25.0.0/24"
+
+volumes:
+  mitmproxy_certs:
+    name: mitmproxy_certs

--- a/templates/mitmproxy/docker-compose.yml
+++ b/templates/mitmproxy/docker-compose.yml
@@ -1,0 +1,44 @@
+# services:
+#   mitmproxy:
+#     image: mitmproxy/mitmproxy
+#     container_name: "{{ service_config.name }}"
+#     restart: always
+#     networks:
+#       mitmproxy_net:
+#         ipv4_address: "{{ service_config.ip_address }}"
+#     command:
+#       - mitmweb
+#       - --mode
+#       - regular@{{ service_config.port }}
+#     ports:
+#       - "{{ service_config.port }}:8082"
+#     healthcheck:
+#       test: "curl -fSs http://localhost:{{ service_config.port }} || exit 1"
+#       interval: 5s
+#       timeout: 10s
+#       retries: 5
+#       start_period: 30s
+
+# networks:
+#   mitmproxy_net:
+#     name: mitmproxy_net
+#     driver: bridge
+#     ipam:
+#       driver: default
+#       config:
+#         - subnet: "172.25.0.0/24"
+services:
+  mitmweb:
+    image: mitmproxy/mitmproxy
+    container_name: "mitmproxy"
+    tty: true
+    ports:
+      - "8080:8080" # Web interface
+      - "8081:8081" # Proxy port
+    command: mitmweb --web-host 0.0.0.0
+    healthcheck:
+      test: "curl -f http://localhost:8081 || exit 1"
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/templates/mitmproxy/docker-entrypoint.sh
+++ b/templates/mitmproxy/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Generate SSL certificate if it doesn't exist
+if [ ! -f /etc/nginx/ssl/nginx.key ] || [ ! -f /etc/nginx/ssl/nginx.crt ]; then
+    echo "Generating SSL certificate..."
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout /etc/nginx/ssl/nginx.key \
+        -out /etc/nginx/ssl/nginx.crt \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+    # Set proper permissions
+    chmod 644 /etc/nginx/ssl/nginx.crt
+    chmod 600 /etc/nginx/ssl/nginx.key
+fi
+
+# Forward all arguments to original entrypoint
+exec /docker-entrypoint.sh "$@"

--- a/templates/mitmproxy/nginx.Dockerfile
+++ b/templates/mitmproxy/nginx.Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx:alpine
+
+# Install OpenSSL
+RUN apk add --no-cache openssl
+
+# Create SSL directory
+RUN mkdir -p /etc/nginx/ssl
+
+# Copy our custom entrypoint
+COPY docker-entrypoint.sh /custom-entrypoint.sh
+RUN chmod +x /custom-entrypoint.sh
+
+ENTRYPOINT ["/custom-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/templates/mitmproxy/nginx/conf.d/default.conf
+++ b/templates/mitmproxy/nginx/conf.d/default.conf
@@ -1,0 +1,128 @@
+server {
+    listen 443 ssl default_server;
+    server_name localhost;
+
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    
+    # SSL configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    location = / {
+        add_header Content-Type text/html;
+        return 200 '<!DOCTYPE html>
+<html>
+<head>
+    <title>Mitmproxy Certificate Installation</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            line-height: 1.5;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 0 20px;
+        }
+        pre {
+            background: #f5f5f5;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }
+        .download-btn {
+            display: inline-block;
+            background: #0066cc;
+            color: white;
+            padding: 10px 20px;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+        .download-btn:hover {
+            background: #0052a3;
+        }
+    </style>
+    <script>
+        window.onload = function() {
+            const host = window.location.hostname;
+            const currentPort = window.location.port;
+            
+            function replaceText(element) {
+                const text = element.innerHTML;
+                return text
+                    .replace(/155\.155\.155\.4:8484/g, `${host}:8484`)
+                    .replace(/155\.155\.155\.4:8585/g, `${host}:8585`)
+                    .replace(/155\.155\.155\.4:9595/g, `${host}:9595`);
+            }
+
+            document.querySelectorAll("pre").forEach(pre => {
+                pre.innerHTML = replaceText(pre);
+            });
+
+            document.querySelectorAll("ul li").forEach(li => {
+                li.innerHTML = replaceText(li);
+                
+                // Update any links inside the li elements
+                const link = li.querySelector("a");
+                if (link) {
+                    const href = link.getAttribute("href");
+                    if (href.includes("9595")) {
+                        const newHref = `https://${host}:9595`;
+                        link.href = newHref;
+                        link.textContent = newHref;
+                    }
+                }
+            });
+        }
+    </script>
+</head>
+<body>
+    <h1>Mitmproxy Certificate Installation</h1>
+    
+    <p>To use mitmproxy for HTTPS inspection, you need to install and trust the certificate:</p>
+    <a href="/cert" class="download-btn">Download Certificate</a>
+    <h2>macOS Installation Instructions</h2>
+    <p>Run these commands in your terminal:</p>
+    <pre>
+# Download the cert
+curl https://155.155.155.4:8484/cert -o mitmproxy-ca-cert.pem
+
+# Add to Keychain and trust it
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain mitmproxy-ca-cert.pem</pre>
+
+    <h2>Verify Installation</h2>
+    <p>After installing the certificate, test the proxy with:</p>
+    <pre>curl -x http://155.155.155.4:8585 https://example.com</pre>
+
+    <p>The proxy should now work without SSL certificate warnings.</p>
+
+    <h2>Access Points</h2>
+    <ul>
+        <li>Proxy UI: <a href="https://155.155.155.4:9595">https://155.155.155.4:9595</a></li>
+        <li>Proxy Address: http://155.155.155.4:8585</li>
+    </ul>
+</body>
+</html>';
+    }
+
+    location = /cert {
+        alias /usr/share/nginx/certs/mitmproxy-ca-cert.pem;
+        default_type application/x-x509-ca-cert;
+        add_header Content-Disposition "attachment; filename=mitmproxy-ca-cert.pem";
+    }
+
+    location /favicon.ico {
+        return 404;
+    }
+
+    location / {
+        return 404;
+    }
+}
+
+server {
+    listen 80;
+    server_name localhost;
+    return 301 https://$host$request_uri;
+}

--- a/vars/mitmproxy/main.yml
+++ b/vars/mitmproxy/main.yml
@@ -7,6 +7,7 @@ mitmproxy_version: "latest"
 service_data_dir: "{{ mitmproxy_data_dir }}"
 service_directories:
   - "{{ mitmproxy_data_dir }}"
+  - "{{ mitmproxy_data_dir }}/nginx/conf.d"
 
 # docker config
 service_config:
@@ -21,3 +22,9 @@ service_config:
 config_templates:
   - src: "../../templates/mitmproxy/docker-compose.yml"
     dest: "{{ mitmproxy_data_dir }}/docker-compose.yml"
+  - src: "../../templates/mitmproxy/nginx/conf.d/default.conf"
+    dest: "{{ mitmproxy_data_dir }}/nginx/conf.d/default.conf"
+  - src: "../../templates/mitmproxy/nginx.Dockerfile"
+    dest: "{{ mitmproxy_data_dir }}/nginx.Dockerfile"
+  - src: "../../templates/mitmproxy/docker-entrypoint.sh"
+    dest: "{{ mitmproxy_data_dir }}/docker-entrypoint.sh"

--- a/vars/mitmproxy/main.yml
+++ b/vars/mitmproxy/main.yml
@@ -1,0 +1,23 @@
+---
+# ansible vars
+mitmproxy_data_dir: "/data/mitmproxy"
+mitmproxy_version: "latest"
+
+# directories
+service_data_dir: "{{ mitmproxy_data_dir }}"
+service_directories:
+  - "{{ mitmproxy_data_dir }}"
+
+# docker config
+service_config:
+  name: mitmproxy
+  port: 8082
+  environment:
+    USER_UID: 1000
+    USER_GID: 1000
+  ip_address: "172.25.0.2"
+
+# templates
+config_templates:
+  - src: "../../templates/mitmproxy/docker-compose.yml"
+    dest: "{{ mitmproxy_data_dir }}/docker-compose.yml"


### PR DESCRIPTION
- Adds MITM proxy support
- Supports TLS for proxy
- Adds NGINX proxy for facilitating cert download and instruction page for connecting clients

## 🔐 MITM Proxy Access

- **Download Certificate**
  ```bash
  curl -o mitmproxy-ca.pem http://155.155.155.4:8484/cert
  ```

- **View Certificate Installation Page**
  ```
  http://155.155.155.4:8484
  ```

- **Access MITM Web Interface**
  ```
  http://155.155.155.4:9595
  ```

- **Use HTTP(S) Proxy**
  ```bash
  # Environment variables
  export http_proxy="http://155.155.155.4:8585"
  export https_proxy="http://155.155.155.4:8585"

  # curl example
  curl -x http://155.155.155.4:8585 https://example.com
  ```

> 📝 **Note**: Replace `155.155.155.4` with your MITM proxy host IP